### PR TITLE
🔨FIX:デバイスサイズに合わせたレイアウトへ修正

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,6 +1,7 @@
 class BookmarksController < ApplicationController
   # ログインしていることを確認
   before_action :require_login
+
   # お気に入り登録、解除実行前にset_libraryメソッドを実行するように指定
   before_action :set_library
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,45 +1,34 @@
 <header class="bg-gray-200 text-gray-700 p-6">
   <div class="container mx-auto flex justify-between items-center">
-    <h1 class="text-lg font-bold mr-4">
+    <h1 class="text-xs md:text-sm lg:text-base font-bold mr-4">
       <%= link_to 'FindLibrary', root_path, class: "text-gray-700 hover:text-blue-200" %>
     </h1>
-    <!-- ハンバーガーメニューアイコン -->
-    <div id="menu-toggle" class="md:hidden cursor-pointer">
-      <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
-    </div>
     <!-- メニュー -->
     <nav>
-      <ul id="menu" class="hidden md:flex space-x-4">
+      <ul id="menu" class="flex space-x-4">
         <!-- メニュー項目 -->
         <!-- 図書館検索は常に表示 -->
-        <li><%= link_to '図書館検索', libraries_path, class: "text-sm text-gray-700 hover:text-blue-200" %></li>
+        <li><%= link_to '図書館検索', libraries_path, class: "text-xs md:text-sm lg:text-base text-gray-700 hover:text-blue-200" %></li>
 
         <!-- ログインしている場合にのみ図書館登録を表示 -->
         <% if current_user %>
-          <li><%= link_to '図書館登録', new_library_path, class: "text-sm text-gray-700 hover:text-blue-200" %></li>
+          <li><%= link_to '図書館登録', new_library_path, class: "text-xs md:text-sm lg:text-base text-gray-700 hover:text-blue-200" %></li>
         <% end %>
 
-        <!-- ログインしていない場合にのみユーザー登録とログインを表示 -->
-        <% unless current_user %>
-          <li><%= link_to 'ユーザー登録', new_user_path, class: "text-sm text-gray-700 hover:text-blue-200" %></li>
-          <li><%= link_to 'ログイン', login_path, class: "text-sm text-gray-700 hover:text-blue-200" %></li>
-        <% end %>
-
-        <!-- マイページとログアウトはログイン時のみ表示 -->
+        <!-- マイページとログアウトはログイン時のみ表示、アバター画像のみ表示 -->
         <% if current_user %>
-          <li><%= link_to 'マイページ', profile_path, class: "text-sm text-gray-700 hover:text-blue-200" %></li>
-          <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: "text-sm text-gray-700 hover:text-blue-200" %></li>
+          <li><%= link_to 'ログアウト', logout_path, data: { turbo_method: :delete }, class: "text-xs md:text-sm lg:text-base text-gray-700 hover:text-blue-200" %></li>
+          <li>
+            <%= link_to profile_path do %>
+              <% if current_user.avatar? %>
+                <%= image_tag current_user.avatar.url, class: "h-8 w-8 rounded-full" %>
+              <% else %>
+                <%= image_tag 'default_avatar.webp', class: "h-8 w-8 rounded-full" %>
+              <% end %>
+            <% end %>
+          </li>
         <% end %>
       </ul>
     </nav>
   </div>
 </header>
-<script>
-  document.addEventListener("DOMContentLoaded", () => {
-    const menuToggle = document.querySelector("#menu-toggle");
-    const menu = document.querySelector("#menu");
-    menuToggle.addEventListener("click", () => {
-      menu.classList.toggle("hidden");
-    });
-  });
-</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,12 @@
     main {
       flex: 1 0 auto;
       background-color: #ffffff; /* main領域を白色に設定 */
-      width: 100%;
+      width: 90%; /* main領域の幅を画面の90%に設定 */
+      max-width: 1200px; /* main領域の最大幅を1200pxに設定 */
+      margin: 20px auto; /* 上下に20pxのマージンを設定し、左右は自動で中央寄せ */
+      padding: 20px; /* 内容周りに20pxのパディングを設定 */
+      box-shadow: 0 4px 6px rgba(0,0,0,0.1); /* 影を追加して立体感を出す */
+      border-radius: 50px; /* 角を丸くする */
     }
     footer {
       flex-shrink: 0;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,16 @@
     footer {
       flex-shrink: 0;
     }
+
+    /* メディアクエリ */
+    /* 以下を適用させるにはビューに各クラス（grid-cols-1, .sm:grid-cols-2, .md:grid-cols-3, .lg:grid-cols-4）を記述 */
+    @media (max-width: 640px) {
+      .grid-cols-1.sm\:grid-cols-2.md\:grid-cols-3.lg\:grid-cols-4 > div {
+        font-size: 0.75em; /* フォントサイズを小さくする */
+        padding: 8px; /* パディングを小さくする */
+        margin: 4px; /* マージンを小さくする */
+      }
+    }
   </style>
 </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,15 +32,22 @@
       flex-shrink: 0;
     }
 
-    /* メディアクエリ */
-    /* 以下を適用させるにはビューに各クラス（grid-cols-1, .sm:grid-cols-2, .md:grid-cols-3, .lg:grid-cols-4）を記述 */
-    @media (max-width: 640px) {
-      .grid-cols-1.sm\:grid-cols-2.md\:grid-cols-3.lg\:grid-cols-4 > div {
-        font-size: 0.75em; /* フォントサイズを小さくする */
-        padding: 8px; /* パディングを小さくする */
-        margin: 4px; /* マージンを小さくする */
-      }
+    /* 自習室詳細情報のタグスタイル */
+    .seat-tag {
+      display: inline-block;
+      padding: 4px 8px;
+      margin: 0 auto 8px 8px; /* 下と右に8pxのマージンを付加 */
+      background-color: #f0f0f0; /* 軽いグレーの背景色 */
+      border: 1px solid #ddd; /* 枠線 */
+      border-radius: 10px; /* 角を丸める */
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* ソフトな影を追加 */
     }
+    .seat-tag h4 {
+      margin: 0; /* h4タグのデフォルトのマージンを削除 */
+      color: #555; /* 文字色 */
+      font-size: 12px; /* フォントサイズを小さく設定 */
+    }
+
   </style>
 </head>
 

--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -38,18 +38,19 @@
     <% end %>
   </div>
 
-  <!-- メディアクエリのクラスを指定し、デバイスサイズに応じてグリッドの列数やフォントサイズ、余白等を調整するよう指定 -->
+  <!-- デバイスサイズに応じてグリッドの列数を調整（スマホデバイスで1列、スモールデバイスで2列...） -->
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mt-10">
     <% @libraries.each do |library| %>
       <div class="border rounded-lg p-6 hover:bg-gray-100">
         <!-- 自習室の有無表示 -->
         <div class="text-center mb-6">
           <div class="border border-gray-400 mx-auto inline-block rounded-full px-6 py-2">
+            <!-- デバイスサイズに応じてフォントサイズを調整（スマホデバイスでxsサイズ、スモールデバイス以上でmdサイズ） -->
             <h4 class="text-xs sm:text-md font-semibold text-gray-500">自習室 <%= library.study_rooms.to_i > 0 ? 'あり' : 'なし' %></h4>
           </div>
         </div>
 
-        <h2 class="text-xs sm:text-lg font-bold text-gray-600 mb-6"><%= library.prefecture %> <%= library.name %></h2>
+        <h2 class="text-sm sm:text-lg font-bold text-gray-600 mb-6"><%= library.prefecture %> <%= library.name %></h2>
 
         <hr class="my-4 border-gray-300 max-w-md mx-auto">
 
@@ -58,16 +59,16 @@
           <% if current_user %>
             <% bookmark = current_user.bookmarks.find_by(library_id: library.id) %>
             <% if bookmark %>
-              <%= link_to library_bookmark_path(library, bookmark), data: { turbo_method: :delete }, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-0.5 px-1 sm:py-2 sm:px-4 rounded focus:outline-none focus:shadow-outline" do %>
+              <%= link_to library_bookmark_path(library, bookmark), data: { turbo_method: :delete }, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-0.5 px-1 sm:py-2 sm:px-4 text-xs sm:text-sm rounded focus:outline-none focus:shadow-outline" do %>
                 <i class="fa-solid fa-star text-yellow-500">お気に入り</i>
               <% end %>
             <% else %>
-              <%= link_to library_bookmarks_path(library), data: { turbo_method: :post }, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-0.5 px-1 sm:py-2 sm:px-4 rounded focus:outline-none focus:shadow-outline" do %>
+              <%= link_to library_bookmarks_path(library), data: { turbo_method: :post }, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-0.5 px-1 sm:py-2 sm:px-4 text-xs sm:text-sm rounded focus:outline-none focus:shadow-outline" do %>
                 <i class="fa-regular fa-star hover:text-yellow-500">お気に入りに登録</i>
               <% end %>
             <% end %>
           <% else %>
-            <%= link_to login_path, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-0.5 px-1 sm:py-2 sm:px-4 rounded focus:outline-none focus:shadow-outline" do %>
+            <%= link_to login_path, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-0.5 px-1 sm:py-2 sm:px-4 text-xs sm:text-sm rounded focus:outline-none focus:shadow-outline" do %>
               <i class="fa-regular fa-star"></i> ログインしてお気に入り登録
             <% end %>
           <% end %>
@@ -86,11 +87,13 @@
 
         <!-- 座席数表示 -->
         <div class="text-center mb-6">
-          <h4 class="text-xs sm:text-sm font-semibold text-gray-500">座席数: <%= I18n.t("enums.library.seats_number.#{library.seats_number}") %></h4>
+          <div class="seat-tag">
+            <h4 class="text-xs sm:text-sm font-semibold text-gray-500">座席数: <%= I18n.t("enums.library.seats_number.#{library.seats_number}") %></h4>
+          </div>
         </div>
 
         <div class="mt-6">
-          <%= link_to '詳細を見る', library_path(library), class: "bg-gray-200 hover:bg-gray-400 text-black font-bold py-1 px-2 sm:py-2 sm:px-4 rounded focus:outline-none focus:shadow-outline" %>
+          <%= link_to '詳細を見る', library_path(library), class: "bg-gray-200 hover:bg-gray-400 text-black font-bold py-2 px-4 sm:py-2.5 sm:px-4.5 text-xs sm:text-sm rounded focus:outline-none focus:shadow-outline" %>
         </div>
       </div>
     <% end %>

--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -38,17 +38,18 @@
     <% end %>
   </div>
 
+  <!-- メディアクエリのクラスを指定し、デバイスサイズに応じてグリッドの列数やフォントサイズ、余白等を調整するよう指定 -->
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mt-10">
     <% @libraries.each do |library| %>
       <div class="border rounded-lg p-6 hover:bg-gray-100">
         <!-- 自習室の有無表示 -->
         <div class="text-center mb-6">
           <div class="border border-gray-400 mx-auto inline-block rounded-full px-6 py-2">
-            <h4 class="text-md font-semibold text-gray-500">自習室 <%= library.study_rooms.to_i > 0 ? 'あり' : 'なし' %></h4>
+            <h4 class="text-xs sm:text-md font-semibold text-gray-500">自習室 <%= library.study_rooms.to_i > 0 ? 'あり' : 'なし' %></h4>
           </div>
         </div>
 
-        <h2 class="text-lg font-bold text-gray-600 mb-6"><%= library.prefecture %> <%= library.name %></h2>
+        <h2 class="text-xs sm:text-lg font-bold text-gray-600 mb-6"><%= library.prefecture %> <%= library.name %></h2>
 
         <hr class="my-4 border-gray-300 max-w-md mx-auto">
 
@@ -57,16 +58,16 @@
           <% if current_user %>
             <% bookmark = current_user.bookmarks.find_by(library_id: library.id) %>
             <% if bookmark %>
-              <%= link_to library_bookmark_path(library, bookmark), data: { turbo_method: :delete }, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" do %>
+              <%= link_to library_bookmark_path(library, bookmark), data: { turbo_method: :delete }, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-0.5 px-1 sm:py-2 sm:px-4 rounded focus:outline-none focus:shadow-outline" do %>
                 <i class="fa-solid fa-star text-yellow-500">お気に入り</i>
               <% end %>
             <% else %>
-              <%= link_to library_bookmarks_path(library), data: { turbo_method: :post }, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" do %>
+              <%= link_to library_bookmarks_path(library), data: { turbo_method: :post }, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-0.5 px-1 sm:py-2 sm:px-4 rounded focus:outline-none focus:shadow-outline" do %>
                 <i class="fa-regular fa-star hover:text-yellow-500">お気に入りに登録</i>
               <% end %>
             <% end %>
           <% else %>
-            <%= link_to login_path, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" do %>
+            <%= link_to login_path, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-0.5 px-1 sm:py-2 sm:px-4 rounded focus:outline-none focus:shadow-outline" do %>
               <i class="fa-regular fa-star"></i> ログインしてお気に入り登録
             <% end %>
           <% end %>
@@ -85,11 +86,11 @@
 
         <!-- 座席数表示 -->
         <div class="text-center mb-6">
-          <h4 class="text-sm font-semibold text-gray-500">座席数: <%= I18n.t("enums.library.seats_number.#{library.seats_number}") %></h4>
+          <h4 class="text-xs sm:text-sm font-semibold text-gray-500">座席数: <%= I18n.t("enums.library.seats_number.#{library.seats_number}") %></h4>
         </div>
 
         <div class="mt-6">
-          <%= link_to '詳細を見る', library_path(library), class: "bg-gray-200 hover:bg-gray-400 text-black font-bold py-3 px-6 rounded focus:outline-none focus:shadow-outline" %>
+          <%= link_to '詳細を見る', library_path(library), class: "bg-gray-200 hover:bg-gray-400 text-black font-bold py-1 px-2 sm:py-2 sm:px-4 rounded focus:outline-none focus:shadow-outline" %>
         </div>
       </div>
     <% end %>

--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -38,16 +38,38 @@
     <% end %>
   </div>
 
-  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-10">
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 mt-10">
     <% @libraries.each do |library| %>
       <div class="border rounded-lg p-6 hover:bg-gray-100">
-        <h2 class="text-lg font-bold text-gray-600 mb-6"><%= library.prefecture %> <%= library.name %></h2>
-        <div class="flex items-center justify-start mb-6">
+        <!-- 自習室の有無表示 -->
+        <div class="text-center mb-6">
+          <div class="border border-gray-400 mx-auto inline-block rounded-full px-6 py-2">
+            <h4 class="text-md font-semibold text-gray-500">自習室 <%= library.study_rooms.to_i > 0 ? 'あり' : 'なし' %></h4>
+          </div>
         </div>
 
-        <div class="flex items-center justify-start mb-6">
-          <div class="w-32 bg-gray-100 p-2 rounded">自習室</div>
-          <div class="ml-8"><%= library.study_rooms.to_i > 0 ? 'あり' : 'なし' %></div>
+        <h2 class="text-lg font-bold text-gray-600 mb-6"><%= library.prefecture %> <%= library.name %></h2>
+
+        <hr class="my-4 border-gray-300 max-w-md mx-auto">
+
+        <!-- お気に入り登録、解除ボタン -->
+        <div class="mb-8">
+          <% if current_user %>
+            <% bookmark = current_user.bookmarks.find_by(library_id: library.id) %>
+            <% if bookmark %>
+              <%= link_to library_bookmark_path(library, bookmark), data: { turbo_method: :delete }, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" do %>
+                <i class="fa-solid fa-star text-yellow-500">お気に入り</i>
+              <% end %>
+            <% else %>
+              <%= link_to library_bookmarks_path(library), data: { turbo_method: :post }, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" do %>
+                <i class="fa-regular fa-star hover:text-yellow-500">お気に入りに登録</i>
+              <% end %>
+            <% end %>
+          <% else %>
+            <%= link_to login_path, class: "bg-transparent hover:bg-gray-200 text-black font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline" do %>
+              <i class="fa-regular fa-star"></i> ログインしてお気に入り登録
+            <% end %>
+          <% end %>
         </div>
 
         <!-- 画像表示 -->
@@ -61,15 +83,9 @@
           </div>
         <% end %>
 
-        <div class="flex items-center justify-start mb-6">
-          <div class="w-32 bg-gray-100 p-2 rounded">休館日</div>
-          <div class="ml-8"><%= library.holiday %></div>
-        </div>
-
-        <!-- 備考の項目をflexコンテナで整列させる -->
-        <div class="flex items-center justify-start mb-6">
-          <div class="w-32 bg-gray-100 p-2 rounded">備考</div>
-          <div class="ml-8"><%= truncate(library.body, length: 100) %></div>
+        <!-- 座席数表示 -->
+        <div class="text-center mb-6">
+          <h4 class="text-sm font-semibold text-gray-500">座席数: <%= I18n.t("enums.library.seats_number.#{library.seats_number}") %></h4>
         </div>
 
         <div class="mt-6">

--- a/app/views/libraries/show.html.erb
+++ b/app/views/libraries/show.html.erb
@@ -53,28 +53,27 @@
       <h4 class="text-md font-semibold text-gray-700">自習室詳細</h4>
     </div>
 
-    <!-- 座席数の表示 -->
+    <!-- 自習室詳細情報のタグ -->
     <div class="text-center mb-6">
-      <h4 class="text-sm font-semibold text-gray-500">座席数: <%= I18n.t("enums.library.seats_number.#{@library.seats_number}") %></h4>
-    </div>
+      <div class="seat-tag">
+        <h4 class="text-sm font-semibold">座席数: <%= I18n.t("enums.library.seats_number.#{@library.seats_number}") %></h4>
+      </div>
 
-    <!-- PC利用可能かの表示 -->
-    <div class="text-center mb-6">
-      <h4 class="text-sm font-semibold text-gray-500">PC利用: <%= I18n.t("enums.library.pc_available.#{@library.pc_available}") %></h4>
-    </div>
+      <div class="seat-tag">
+        <h4 class="text-sm font-semibold">PC利用: <%= I18n.t("enums.library.pc_available.#{@library.pc_available}") %></h4>
+      </div>
 
-    <!-- WiFi利用可能かの表示 -->
-    <div class="text-center mb-6">
-      <h4 class="text-sm font-semibold text-gray-500">WiFi: <%= I18n.t("enums.library.wifi_available.#{@library.wifi_available}") %></h4>
-    </div>
+      <div class="seat-tag">
+        <h4 class="text-sm font-semibold">WiFi: <%= I18n.t("enums.library.wifi_available.#{@library.wifi_available}") %></h4>
+      </div>
 
-    <!-- 電源の有無の表示 -->
-    <div class="text-center mb-6">
-      <h4 class="text-sm font-semibold text-gray-500">電源: <%= I18n.t("enums.library.power_available.#{@library.power_available}") %></h4>
-    </div>
+      <div class="seat-tag">
+        <h4 class="text-sm font-semibold">電源: <%= I18n.t("enums.library.power_available.#{@library.power_available}") %></h4>
+      </div>
 
-    <div class="text-center mb-6">
-      <h4 class="text-sm font-semibold text-gray-500">備考: <%= @library.body %></h4>
+      <div class="seat-tag">
+        <h4 class="text-sm font-semibold">備考: <%= @library.body %></h4>
+      </div>  
     </div>
   </div>
 

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,6 +1,6 @@
 <div class="my-10 sm:my-20 md:my-40 lg:my-48 mx-auto max-w-xl sm:max-w-2xl md:max-w-3xl lg:max-w-4xl px-2 sm:px-4 md:px-6 lg:px-8 text-center">
   <h1 class="text-2xl sm:text-3xl md:text-4xl lg:text-4xl font-bold text-gray-600 mb-8 sm:mb-12 md:mb-14 lg:mb-16">ようこそ FindLibrary へ</h1>
-  <p class="text-sm sm:text-md md:text-lg lg:text-lg text-gray-600 mb-8 sm:mb-12 md:mb-14 lg:mb-16">このアプリは自習室のある図書館を簡単に検索できるサービスです。</p>
+  <p class="text-sm sm:text-md md:text-lg lg:text-xl text-gray-600 mb-8 sm:mb-12 md:mb-14 lg:mb-16">このアプリは自習室のある図書館を簡単に検索できるサービスです。</p>
 
   <hr class="my-4 border-gray-300">
 
@@ -9,13 +9,12 @@
   <p class="text-sm sm:text-md md:text-lg lg:text-lg text-gray-600 mb-4">"静かな場所で勉強したいなぁ"</p>
   <p class="text-sm sm:text-md md:text-lg lg:text-lg text-gray-600 mb-4">"どこに自習室があるんだろう"</p>
 
-
   <figure class="mx-auto">
     <%= image_tag "top.webp", class: 'mt-2 w-80 mx-auto mb-8' %>
   </figure>
 
   <p class="text-xl sm:text-2xl md:text-3xl lg:text-3xl font-bold text-gray-700 mb-6 text-center">FindLibraryがお手伝いします</p>
-  <p class="text-sm sm:text-md md:text-lg lg:text-lg text-gray-600 mb-8 sm:mb-12 md:mb-14 lg:mb-16">都道府県、自習室の有無、休館日別に図書館を検索できます</p>
+  <p class="text-sm sm:text-md md:text-lg lg:text-lg text-gray-600 mb-8 sm:mb-12 md:mb-14 lg:mb-16">都道府県、自習室の有無別に図書館を検索できます</p>
   <figure class="mx-auto">
     <%= image_tag "iphone.webp", class: 'mt-2 w-80 mx-auto mb-8' %>
   </figure>
@@ -23,8 +22,7 @@
   <hr class="my-4 border-gray-300">
 
   <p class="text-xl sm:text-2xl md:text-3xl lg:text-3xl font-bold text-gray-700 mb-6 text-center">さっそくはじめてみる</p>
-  <p class="text-sm sm:text-md md:text-lg lg:text-lg text-gray-600 mb-8 sm:mb-12 md:mb-14 lg:mb-16">「図書館を探す」はユーザー登録なしでもご利用いただけます</p>
+  <p class="text-xs sm:text-sm md:text-md lg:text-lg text-gray-600 mb-8 sm:mb-12 md:mb-14 lg:mb-16">「図書館を探す」はユーザー登録なしでもご利用いただけます</p>
   <%= link_to '図書館を探す', libraries_path, class: "bg-blue-100 hover:bg-blue-400 text-black font-bold py-2 sm:py-3 md:py-4 lg:py-4 px-4 sm:px-6 md:px-8 lg:px-8 rounded focus:outline-none focus:shadow-outline ml-2 sm:ml-3 md:ml-4 lg:ml-4" %>
   <%= link_to 'ユーザー登録', new_user_path, class: "bg-blue-100 hover:bg-blue-400 text-black font-bold py-2 sm:py-3 md:py-4 lg:py-4 px-4 sm:px-6 md:px-8 lg:px-8 rounded focus:outline-none focus:shadow-outline ml-2 sm:ml-3 md:ml-4 lg:ml-4" %>
-  <%= link_to 'ログイン', login_path, class: "bg-blue-100 hover:bg-blue-400 text-black font-bold py-2 sm:py-3 md:py-4 lg:py-4 px-4 sm:px-6 md:px-8 lg:px-8 rounded focus:outline-none focus:shadow-outline ml-2 sm:ml-3 md:ml-4 lg:ml-4" %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,18 +12,18 @@ ja:
         seats_unknown: "わからない"
 
       pc_available:
-        pc_unavailable: "PC利用不可"
-        pc_available: "PC利用可能"
+        pc_unavailable: "不可"
+        pc_available: "可能"
         pc_unknown: "わからない"
 
       wifi_available:
-        wifi_unavailable: "WiFi利用不可"
-        wifi_available: "WiFi利用可能"
+        wifi_unavailable: "不可"
+        wifi_available: "可能"
         wifi_unknown: "わからない"
 
       power_available:
-        power_unavailable: "電源利用不可"
-        power_available: "電源利用可能"
+        power_unavailable: "不可"
+        power_available: "可能"
         power_unknown: "わからない"
 
     # commentモデルで定義したenum
@@ -37,16 +37,16 @@ ja:
         comments_seats_unknown: "わからない"
 
       comments_pc_available:
-        comments_pc_unavailable: "PC利用不可"
-        comments_pc_available: "PC利用可能"
+        comments_pc_unavailable: "不可"
+        comments_pc_available: "可能"
         comments_pc_unknown: "わからない"
 
       comments_wifi_available:
-        comments_wifi_unavailable: "WiFi利用不可"
-        comments_wifi_available: "WiFi利用可能"
+        comments_wifi_unavailable: "不可"
+        comments_wifi_available: "可能"
         comments_wifi_unknown: "わからない"
 
       comments_power_available:
-        comments_power_unavailable: "電源利用不可"
-        comments_power_available: "電源利用可能"
+        comments_power_unavailable: "不可"
+        comments_power_available: "可能"
         comments_power_unknown: "わからない"


### PR DESCRIPTION
### 実装したこと

- [x] Responsive Viewer（chrome拡張機能）をインストール
- [x] 投稿一覧画面と投稿詳細画面のレイアウトを修正

・デバイスサイズに応じて文字サイズが調整されるように設定
・自習室情報の項目をタグっぽくする

### できなかったこと、また今後したいこと
・デバイスサイズに応じた画像、検索フォームのサイズ調整
