### PR TITLE
🔨Fix:コメント一覧のバグの対応/git管理下からnode_modulesを除外

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ config/environments/*.local.yml
 .env
 /.env
 
-/node_modules
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 
-# .envファイルをgithub上にアップさせないように設定
+# github上にアップさせないように設定
 .env
 /.env
+
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ config/environments/*.local.yml
 .env
 /.env
 
-node_modules/
+/node_modules

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,12 +3,11 @@ class CommentsController < ApplicationController
   before_action :require_login
 
   def create
-    # コメントを追加する図書館を特定
+    # コメントする図書館を特定
     @library = Library.find(params[:library_id])
-    # 特定の図書館に新しいコメントを構築し、現在ログインしているユーザーをコメントユーザーとして設定
-    @comment = @library.comments.build(comment_params)
+    # 新しいコメントを直接作成し、パラメーターからlibrary_idを取得して設定
+    @comment = Comment.new(comment_params)
     @comment.user = current_user
-    # コメント保存の条件分岐
     if @comment.save
       redirect_to @library, notice: 'コメントを追加しました。'
     else
@@ -17,12 +16,9 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    # 削除するコメントを特定
+    # 削除するコメントと属する図書館を特定
     @comment = Comment.find(params[:id])
-    # コメントが属する図書館を特定
     @library = @comment.library
-    # 現在ログイン中のユーザーによって作成された場合のみコメントを削除
-    # コメント削除の条件分岐
     if @comment.user == current_user
       @comment.destroy
       redirect_to @library, notice: 'コメントを削除しました。'
@@ -36,6 +32,6 @@ class CommentsController < ApplicationController
   # Strong Parameters
   # フォームから送信されたデータのうち、許可されたパラメータのみ使用可能にする
   def comment_params
-    params.require(:comment).permit(:comments_body, :comments_seats_number, :comments_pc_available, :comments_wifi_available, :comments_power_available)
+    params.require(:comment).permit(:comments_body, :comments_seats_number, :comments_pc_available, :comments_wifi_available, :comments_power_available, :library_id)
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,12 +1,11 @@
 class CommentsController < ApplicationController
-  # ユーザーがログインしていることを確認
   before_action :require_login
 
   def create
     # コメントする図書館を特定
     @library = Library.find(params[:library_id])
-    # 新しいコメントを直接作成し、パラメーターからlibrary_idを取得して設定
-    @comment = Comment.new(comment_params)
+    # 新しいコメントを直接作成し、パラメーターからidを取得して設定
+    @comment = @library.comments.build(comment_params)
     @comment.user = current_user
     if @comment.save
       redirect_to @library, notice: 'コメントを追加しました。'
@@ -32,6 +31,6 @@ class CommentsController < ApplicationController
   # Strong Parameters
   # フォームから送信されたデータのうち、許可されたパラメータのみ使用可能にする
   def comment_params
-    params.require(:comment).permit(:comments_body, :comments_seats_number, :comments_pc_available, :comments_wifi_available, :comments_power_available, :library_id)
+    params.require(:comment).permit(:comments_body, :comments_seats_number, :comments_pc_available, :comments_wifi_available, :comments_power_available)
   end
 end

--- a/app/views/libraries/show.html.erb
+++ b/app/views/libraries/show.html.erb
@@ -119,7 +119,7 @@
 
   <!-- コメントフォーム -->
   <div class="container mx-auto max-w-md px-4 text-center my-8">
-    <%= form_with(model: [@library, @comment], local: true, html: {class: "card border rounded-lg p-6 hover:bg-gray-100"}) do |form| %>
+    <%= form_with(model: @comment, url: library_comments_path(@library), local: true, html: {class: "card border rounded-lg p-6 hover:bg-gray-100"}) do |form| %>
       <div class="mb-6">
         <%= form.label :comments_body, "コメントを追加する", class: "block text-gray-700 text-md font-bold mb-2" %>
         <%= form.text_area :comments_body, rows: 4, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline", placeholder: "追加情報等あればご自由にご記入ください" %>


### PR DESCRIPTION
### 3/3発生したエラーついて
発生した際のプルリクエスト：https://github.com/nanako45a/find_library/pull/100#issuecomment-1975167380
再度講師へ相談し以下ご助言いただく。
```
下記のmodelで利用するコメントのインスタンスをアソシエーションを利用せずに定義するといいかなと！
@comment = @library.comments.build
⇩
@comment = Comment.new
```
### 3/12試したこと
①library_idをパラメータとして手動でセットするため、CommentsControllerのcreateアクションを修正
変更点：`@comment = @library.comments.build(comment_params)`を`@comment = Comment.new(comment_params)`に置き換え
変更点：`comment_paramsメソッド`内でlibrary_idを許可されたパラメータに追加
```
# 変更後のコード
class CommentsController < ApplicationController
  before_action :require_login

  def create
    @library = Library.find(params[:library_id])
    @comment = Comment.new(comment_params)
    @comment.user = current_user
    if @comment.save
      redirect_to @library, notice: 'コメントを追加しました。'
    else
      redirect_to @library, alert: 'コメントの追加に失敗しました。'
    end
  end

  # destroyアクションの処理

  private
  def comment_params
    params.require(:comment).permit(:comments_body, :comments_seats_number, :comments_pc_available, :comments_wifi_available, :comments_power_available, :library_id)
  end
end
```
→これによりCommentsControllerのcreateアクションをアソシエーションを使用せずにコメントインスタンスを直接Comment.newを使用して作成し、library_idをパラメータから取得して手動で設定できるように修正

②フォーム側でもlibrary_idを送信させるため、urlオプションでコメントの送信先を指定。
【app/views/libraries/show.html.erb  】
変更前：`<%= form_with(model: [@library, @comment], local: tru.....`
変更後：`<%= form_with(model: @comment, url: library_comments_path(@library), local:.....%>`
③コメント投稿した際の挙動
1.ブラウザ上
→「コメントの追加に失敗しました。」とのアラートが表示される
2.rails cでデータベースに保存されているか確認
```
irb(main):001> Comment.all
  Comment Load (0.8ms)  SELECT "comments".* FROM "comments" /* loading for pp */ LIMIT $1  [["LIMIT", 11]]
=> []
```
→コメントが保存できていない
3.コメント投稿ボタンを押した際のログを確認
→Commentscontrollerのcreateアクションの処理は実行されている。
```
19:15:24 web.1  | Started POST "/libraries/1/comments" for ::1 at 2024-03-12 19:15:24 +0900
19:15:24 web.1  | Processing by CommentsController#create as TURBO_STREAM
19:15:24 web.1  |   Parameters: {"authenticity_token"=>"[FILTERED]", "comment"=>{"comments_body"=>"wifi回線良好でした"}, "commit"=>"投稿", "library_id"=>"1"}
19:15:24 web.1  |   User Load (0.7ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
19:15:24 web.1  |   Library Load (0.6ms)  SELECT "libraries".* FROM "libraries" WHERE "libraries"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
19:15:24 web.1  |   ↳ app/controllers/comments_controller.rb:7:in `create'
19:15:24 web.1  | Redirected to http://localhost:3000/libraries/1
19:15:24 web.1  | Completed 302 Found in 53ms (ActiveRecord: 7.0ms | Allocations: 32940)
19:15:24 web.1  | 
19:15:24 web.1  | 
19:15:24 web.1  | Started GET "/libraries/1" for ::1 at 2024-03-12 19:15:24 +0900
19:15:24 web.1  | Processing by LibrariesController#show as TURBO_STREAM
19:15:24 web.1  |   Parameters: {"id"=>"1"}
19:15:24 web.1  |   Library Load (0.4ms)  SELECT "libraries".* FROM "libraries" WHERE "libraries"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
19:15:24 web.1  |   ↳ app/controllers/libraries_controller.rb:15:in `show'
19:15:24 web.1  |   Rendering layout layouts/application.html.erb
19:15:24 web.1  |   Rendering libraries/show.html.erb within layouts/application
19:15:24 web.1  |   User Load (0.2ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
19:15:24 web.1  |   ↳ app/views/libraries/_bookmark_button.html.erb:4
19:15:24 web.1  |   Bookmark Load (1.7ms)  SELECT "bookmarks".* FROM "bookmarks" WHERE "bookmarks"."user_id" = $1 AND "bookmarks"."library_id" = $2 LIMIT $3  [["user_id", 1], ["library_id", 1], ["LIMIT", 1]]
19:15:24 web.1  |   ↳ app/views/libraries/_bookmark_button.html.erb:5
19:15:24 web.1  |   Rendered libraries/_bookmark_button.html.erb (Duration: 4.4ms | Allocations: 3390)
19:15:24 web.1  |   User Load (0.1ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
19:15:24 web.1  |   ↳ app/views/libraries/show.html.erb:104
19:15:24 web.1  |   Comment Exists? (0.9ms)  SELECT 1 AS one FROM "comments" WHERE "comments"."library_id" = $1 LIMIT $2  [["library_id", 1], ["LIMIT", 1]]
19:15:24 web.1  |   ↳ app/views/libraries/show.html.erb:136
19:15:24 web.1  |   Rendered libraries/show.html.erb within layouts/application (Duration: 10.1ms | Allocations: 8620)
19:15:24 web.1  |   Rendered layouts/_header.html.erb (Duration: 0.5ms | Allocations: 837)
19:15:24 web.1  |   Rendered layouts/_footer.html.erb (Duration: 0.1ms | Allocations: 214)
19:15:24 web.1  |   Rendered layout layouts/application.html.erb (Duration: 23.4ms | Allocations: 31820)
19:15:24 web.1  | Completed 200 OK in 27ms (Views: 21.4ms | ActiveRecord: 3.4ms | Allocations: 34540)
```
→コメント保存自体できなくなったため、一旦アソシエーションを利用した定義に戻す